### PR TITLE
Changes to setup.py for building on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,20 +10,35 @@
 # contain the HDF5 lib/ and include/ directories.
 hdf5_location = "/usr/"
 
+import sys
 from distutils.core import setup, Extension
 import numpy.distutils.misc_util
 
 numpy_include_dir = numpy.distutils.misc_util.get_numpy_include_dirs()
 idirs             = numpy_include_dir + [hdf5_location+"/include"]
 ldirs             = [hdf5_location+"/lib"]
-rdirs             = ldirs
+
+if sys.platform.startswith("win"):
+    # On Windows, must not specify run time search path
+    rdirs = []
+    # For static HDF5 library
+    #extra_compile_args = ["-D_HDF5USEDLL_",]
+    # For dynamic HDF5 library
+    extra_compile_args = ["-DH5_BUILT_AS_DYNAMIC_LIB",]
+else:
+    # Set runtime library search path on non-Windows systems
+    rdirs = ldirs
+    # No need for extra args in this case
+    extra_compile_args = []
 
 read_eagle_module = Extension('_read_eagle',
                               sources = ['./src/_read_eagle.c','./src/read_eagle.c'],
                               libraries=["hdf5"],
                               include_dirs =idirs,
                               library_dirs =ldirs,
-                              runtime_library_dirs=rdirs)
+                              runtime_library_dirs=rdirs,
+                              extra_compile_args=extra_compile_args,
+                          )
 
 setup (name         = 'ReadEagle',
        version      = '1.0',


### PR DESCRIPTION
It seems that on Windows we shouldn't specify a run time library path and we also need some extra preprocessor macros. This PR modifies setup.py to check sys.platform and modify the parameters to the Extension() call if we're on Windows.