### PR TITLE
Modifed to handle unsigned ints/long longs correctly

### DIFF
--- a/src/_read_eagle.c
+++ b/src/_read_eagle.c
@@ -387,10 +387,20 @@ static PyObject *_read_eagle_read_dataset(PyObject *self, PyObject *args)
       hdf5_type = H5T_NATIVE_FLOAT;
       result = (PyArrayObject *) PyArray_SimpleNew(rank, dims, NPY_FLOAT);
     }
-  else
+  else if(tc==t_double)
     {
       hdf5_type = H5T_NATIVE_DOUBLE;
       result = (PyArrayObject *) PyArray_SimpleNew(rank, dims, NPY_DOUBLE);
+    }
+  else if(tc==t_uint)
+    {
+      hdf5_type = H5T_NATIVE_UINT;
+      result = (PyArrayObject *) PyArray_SimpleNew(rank, dims, NPY_UINT);
+    }
+  else if(tc==t_ulong_long)
+    {
+      hdf5_type = H5T_NATIVE_ULLONG;
+      result = (PyArrayObject *) PyArray_SimpleNew(rank, dims, NPY_ULONGLONG);
     }
 
   /* Get a pointer to the data buffer */
@@ -476,10 +486,20 @@ static PyObject *_read_eagle_read_extra_dataset(PyObject *self, PyObject *args)
       hdf5_type = H5T_NATIVE_FLOAT;
       result = (PyArrayObject *) PyArray_SimpleNew(rank, dims, NPY_FLOAT);
     }
-  else
+  else if(tc==t_double)
     {
       hdf5_type = H5T_NATIVE_DOUBLE;
       result = (PyArrayObject *) PyArray_SimpleNew(rank, dims, NPY_DOUBLE);
+    }
+  else if(tc==t_uint)
+    {
+      hdf5_type = H5T_NATIVE_UINT;
+      result = (PyArrayObject *) PyArray_SimpleNew(rank, dims, NPY_UINT);
+    }
+  else if(tc==t_ulong_long)
+    {
+      hdf5_type = H5T_NATIVE_ULLONG;
+      result = (PyArrayObject *) PyArray_SimpleNew(rank, dims, NPY_ULONGLONG);
     }
 
   /* Get a pointer to the data buffer */

--- a/src/read_eagle.c
+++ b/src/read_eagle.c
@@ -1312,6 +1312,7 @@ int get_extra_dataset_info(EagleSnapshot *snap, int itype, char *dset_name, Type
   hid_t dtype_id;
   H5T_class_t dclass;
   size_t dsize;
+  H5T_sign_t sign;
 
   /* Range check on itype */
   if(itype<0 || itype>5)
@@ -1360,12 +1361,24 @@ int get_extra_dataset_info(EagleSnapshot *snap, int itype, char *dset_name, Type
   *rank = H5Sget_simple_extent_ndims(dspace_id); 
   dclass = H5Tget_class(dtype_id);
   dsize = H5Tget_size(dtype_id);
+  sign = H5Tget_sign(dtype_id);
+
   if(dclass==H5T_INTEGER)
     {
-      if(dsize <= 4)
-	*typecode = t_int;
+      if(sign==H5T_SGN_NONE)
+        {
+          if(dsize <= 4)
+            *typecode = t_uint;
+          else
+            *typecode = t_ulong_long;
+        }
       else
-	*typecode = t_long_long;
+        {
+          if(dsize <= 4)
+            *typecode = t_int;
+          else
+            *typecode = t_long_long;
+        }
     }
   else if(dclass==H5T_FLOAT)
     {

--- a/src/read_eagle.h
+++ b/src/read_eagle.h
@@ -42,7 +42,9 @@ typedef enum e_TypeCode
     t_int       = 0,
     t_long_long = 1,
     t_float     = 2,
-    t_double    = 3
+    t_double    = 3,
+    t_uint      = 4,
+    t_ulong_long = 5
   } TypeCode;
 
 /* Return a pointer to the last error message */
@@ -180,7 +182,8 @@ long long read_extra_dataset(EagleSnapshot *snap, int itype, char *name, hid_t h
 #define read_dataset_float(snap,itype,name,buf,n) read_extra_dataset(snap,itype,name,H5T_NATIVE_FLOAT,buf,n,NULL)
 #define read_dataset_double(snap,itype,name,buf,n) read_extra_dataset(snap,itype,name,H5T_NATIVE_DOUBLE,buf,n,NULL)
 #define read_dataset_long_long(snap,itype,name,buf,n) read_extra_dataset(snap,itype,name,H5T_NATIVE_LLONG,buf,n,NULL)
-
+#define read_dataset_unsigned_int(snap,itype,name,buf,n) read_extra_dataset(snap,itype,name,H5T_NATIVE_UINT,buf,n,NULL)
+#define read_dataset_unsigned_long_long(snap,itype,name,buf,n) read_extra_dataset(snap,itype,name,H5T_NATIVE_ULLONG,buf,n,NULL)
 
 /*
   Return information about a dataset given its name

--- a/src/read_eagle_f.c
+++ b/src/read_eagle_f.c
@@ -111,7 +111,11 @@ void FC_GLOBAL(readdatasetf, READDATASETF)(long long *nread, EagleSnapshot **sna
     dtype_id = H5T_NATIVE_FLOAT;
   else if(*typecode==3)
     dtype_id = H5T_NATIVE_DOUBLE;
-  
+  else if(*typecode==4)
+    dtype_id = H5T_NATIVE_UINT;
+  else if(*typecode==5)
+    dtype_id = H5T_NATIVE_ULLONG;
+
   *nread = read_dataset(*snap, *itype, name, dtype_id, buf, *n);
 }
 


### PR DESCRIPTION
The code previously read all 64 bit integer values as signed, even if the underlying dataset was unsigned. This causes problems when the values don't fit in a signed integer because HDF5 clamps the values to the closest value that can be represented. This is particularly problematic with particle IDs because they can become non-unique.

This PR allows reading unsigned arrays in C and Python. In Fortran, we read the unsigned data into a signed array with no conversion, so at least the values will still be unique (although Fortran will interpret the out of range values as negative).