### PR TITLE
Added FileNotFoundError exception when attempting to open a file that does not exist

### DIFF
--- a/src/read_eagle.py
+++ b/src/read_eagle.py
@@ -7,6 +7,8 @@
 #
 import _read_eagle
 
+from os.path import exists
+
 class EagleSnapshotClosedException(Exception):
     pass
 
@@ -15,6 +17,15 @@ class EagleSnapshot:
     
     def __init__(self, fname):
         """Open a new snapshot"""
+        # First, check if the file exists as otherwise we call into the
+        # C HDF5 library and get lots of warnings.
+        if not exists(fname):
+            # Need to set self.open as it's checked in __del__.
+            self.open = False
+            raise FileNotFoundError(
+                "Unable to open file %s" % fname
+            )
+    
         try:
             (self.snap, n0, n1, n2, n3, n4, n5, 
              self.boxsize, self.numfiles, self.hashbits) = _read_eagle.open_snapshot(fname)


### PR DESCRIPTION
This change allows `read_eagle.EagleSnapshot` to raise the standard `FileNotFoundError` when attempting to open a file that does not exist.

Test script:
```python
import read_eagle

snap = read_eagle.EagleSnapshot("./this_file_does_not_exist.hdf5")
```

Old behaviour:
```
python3 test_read_eagle.py 
HDF5-DIAG: Error detected in HDF5 (1.10.5) thread 0:
  #000: H5F.c line 509 in H5Fopen(): unable to open file
    major: File accessibilty
    minor: Unable to open file
  #001: H5Fint.c line 1498 in H5F_open(): unable to open file: time = Wed Oct 16 10:48:50 2019
, name = './this_file_does_not_exist.hdf5', tent_flags = 0
    major: File accessibilty
    minor: Unable to open file
  #002: H5FD.c line 734 in H5FD_open(): open failed
    major: Virtual File Layer
    minor: Unable to initialize object
  #003: H5FDsec2.c line 346 in H5FD_sec2_open(): unable to open file: name = './this_file_does_not_exist.hdf5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0
    major: File accessibilty
    minor: Unable to open file
Traceback (most recent call last):
  File "test_read_eagle.py", line 3, in <module>
    snap = read_eagle.EagleSnapshot("./this_file_does_not_exist.hdf5")
  File "/Users/mphf18/Documents/hacktoberfest/gcc_env_clean/lib/python3.7/site-packages/read_eagle.py", line 20, in __init__
    self.boxsize, self.numfiles, self.hashbits) = _read_eagle.open_snapshot(fname)
_read_eagle.error: Unable to open file: ./this_file_does_not_exist.hdf5
```
Note the HDF5 errors from the C library and the non-standard internal exception from `_read_eagle`.

New behaviour:
```
python3 test_read_eagle.py 
Traceback (most recent call last):
  File "test_read_eagle.py", line 3, in <module>
    snap = read_eagle.EagleSnapshot("./this_file_does_not_exist.hdf5")
  File "/Users/mphf18/Documents/hacktoberfest/gcc_env/lib/python3.7/site-packages/read_eagle.py", line 26, in __init__
    "Unable to open file %s" % fname
FileNotFoundError: Unable to open file ./this_file_does_not_exist.hdf5
```

Example use case: Attempting to open a file as an `EagleSnapshot` that may or may not exist is somewhat standard behaviour, and being able to use the standard `try: except FileNotFoundError:` practice would be nice.